### PR TITLE
Update bert_loader.py

### DIFF
--- a/open_intent_detection/dataloaders/bert_loader.py
+++ b/open_intent_detection/dataloaders/bert_loader.py
@@ -61,7 +61,7 @@ def get_examples(args, base_attrs, mode):
 
         examples = []
         for example in ori_examples:
-            if (example.label in base_attrs['label_list']) and (example.label is not base_attrs['unseen_label']):
+            if (example.label in base_attrs['label_list']) and (example.label != base_attrs['unseen_label']):
                 examples.append(example)
             else:
                 example.label = base_attrs['unseen_label']


### PR DESCRIPTION
解决代码中赋值"oos"和文件中读取"oos" 不一致的情况
![image](https://github.com/thuiar/TEXTOIR/assets/9687324/b7027ef0-48d8-4206-afbb-ae922697a3e0)

a1='oos'
a2=open('onlyoos.txt','r').read().strip()  # a2 也是oos
a1 is not a2   #这句话返回True，py认为代码中赋值的'oos'字符串地址与文件中读取的不是同一条字符串，所以此处最好用 a1 != a2